### PR TITLE
argo-dsl-add-support-for-dag-task-hooks

### DIFF
--- a/argo_workflow_tools/dsl/dag_task.py
+++ b/argo_workflow_tools/dsl/dag_task.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Callable, Mapping, Union, List
+from typing import Callable, Mapping, Union, List, Optional
 
 from argo_workflow_tools.dsl.input_definition import InputDefinition
 from argo_workflow_tools.dsl.node_properties import (
@@ -18,6 +18,8 @@ class NodeReference(object):
     name: str
     outputs: Mapping[str, InputDefinition]
     func: Callable
+    pre_func_hooks: Optional[Callable[[], None]]
+    post_func_hooks: Optional[Callable[[], None]]
     node: str
     arguments: Mapping[str, Union[InputDefinition]]
     wait_for: List[InputDefinition]

--- a/argo_workflow_tools/dsl/dsl_decorators.py
+++ b/argo_workflow_tools/dsl/dsl_decorators.py
@@ -104,8 +104,8 @@ def Task(
     env: List[k8s.EnvVar] = None,
     env_from: List[k8s.EnvFromSource] = None,
     image_pull_policy: str = None,
-    pre_task_hook: Optional[Callable[[], None]] = None,
-    post_task_hook: Optional[Callable[[], None]] = None,
+    pre_hook: Optional[Callable[[], None]] = None,
+    post_hook: Optional[Callable[[], None]] = None,
 ) -> Callable[[Callable], Node]:
     if inputs is None:
         inputs = {}
@@ -134,8 +134,8 @@ def Task(
                 inputs=inputs,
                 outputs=outputs,
             ),
-            pre_task_hook=pre_task_hook,
-            post_task_hook=post_task_hook,
+            pre_hook=pre_hook,
+            post_hook=post_hook,
         )
 
     return decorator

--- a/argo_workflow_tools/dsl/dsl_decorators.py
+++ b/argo_workflow_tools/dsl/dsl_decorators.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 
 import argo_workflow_tools.models.io.argoproj.workflow.v1alpha1 as argo
 import argo_workflow_tools.models.io.k8s.api.core.v1 as k8s
@@ -104,6 +104,8 @@ def Task(
     env: List[k8s.EnvVar] = None,
     env_from: List[k8s.EnvFromSource] = None,
     image_pull_policy: str = None,
+    pre_task_hook: Optional[Callable[[], None]] = None,
+    post_task_hook: Optional[Callable[[], None]] = None,
 ) -> Callable[[Callable], Node]:
     if inputs is None:
         inputs = {}
@@ -132,6 +134,8 @@ def Task(
                 inputs=inputs,
                 outputs=outputs,
             ),
+            pre_task_hook=pre_task_hook,
+            post_task_hook=post_task_hook,
         )
 
     return decorator

--- a/argo_workflow_tools/dsl/node.py
+++ b/argo_workflow_tools/dsl/node.py
@@ -275,7 +275,7 @@ class DAGNode(Node):
 
 class TaskNode(Node):
     def __init__(self, func: Callable, properties: TaskNodeProperties,
-                 pre_task_hook: Optional[Callable[[], None]], post_task_hook: Optional[Callable[[], None]]):
+                 pre_hook: Optional[Callable[[], None]], post_hook: Optional[Callable[[], None]]):
         """
         reporesents a task leaf node in the workflow graph
         Parameters
@@ -285,8 +285,8 @@ class TaskNode(Node):
         """
         super().__init__(func)
         self.properties = properties
-        self._pre_task_hook = pre_task_hook
-        self._post_task_hook = post_task_hook
+        self._pre_hook = pre_hook
+        self._post_hook = post_hook
 
     def __call__(self, *args, **kwargs) -> Any:
         """
@@ -362,8 +362,8 @@ class TaskNode(Node):
                 id=guid,
                 name=sanitize_name(self._func.__name__),
                 func=self._func,
-                pre_func_hooks=self._pre_task_hook,
-                post_func_hooks=self._post_task_hook,
+                pre_func_hooks=self._pre_hook,
+                post_func_hooks=self._post_hook,
                 wait_for=self._get_wait(kwargs),
                 continue_on_fail=kwargs.get("continue_on_fail"),
                 exit=exit_handler,
@@ -380,13 +380,13 @@ class TaskNode(Node):
             return outputs
 
     def _call_task_func_with_hooks(self, args, cleaned_kwargs):
-        if self._pre_task_hook is not None:
-            self._pre_task_hook()
+        if self._pre_hook is not None:
+            self._pre_hook()
         try:
             return self._func(*args, **cleaned_kwargs)
         finally:
-            if self._post_task_hook is not None:
-                self._post_task_hook()
+            if self._post_hook is not None:
+                self._post_hook()
 
 
 class WorkflowTemplateNode(DAGNode):

--- a/argo_workflow_tools/dsl/node.py
+++ b/argo_workflow_tools/dsl/node.py
@@ -1,6 +1,6 @@
 import inspect
 from abc import abstractmethod
-from typing import Any, Callable, Dict, Iterable, Mapping, Sequence, cast, List
+from typing import Any, Callable, Dict, Iterable, Mapping, Sequence, cast, List, Optional
 
 from argo_workflow_tools.dsl import building_mode_context as context
 from argo_workflow_tools.dsl.dag_task import (
@@ -255,6 +255,8 @@ class DAGNode(Node):
                 id=guid,
                 name=sanitize_name(self._func.__name__),
                 func=self._func,
+                pre_func_hooks=None,
+                post_func_hooks=None,
                 wait_for=self._get_wait(kwargs),
                 continue_on_fail=kwargs.get("continue_on_fail"),
                 exit=exit_handler,
@@ -272,7 +274,8 @@ class DAGNode(Node):
 
 
 class TaskNode(Node):
-    def __init__(self, func: Callable, properties: TaskNodeProperties):
+    def __init__(self, func: Callable, properties: TaskNodeProperties,
+                 pre_task_hook: Optional[Callable[[], None]], post_task_hook: Optional[Callable[[], None]]):
         """
         reporesents a task leaf node in the workflow graph
         Parameters
@@ -282,6 +285,8 @@ class TaskNode(Node):
         """
         super().__init__(func)
         self.properties = properties
+        self._pre_task_hook = pre_task_hook
+        self._post_task_hook = post_task_hook
 
     def __call__(self, *args, **kwargs) -> Any:
         """
@@ -295,7 +300,7 @@ class TaskNode(Node):
             conditions = collect_conditions()
             if all([condition.value for condition in conditions]):
                 try:
-                    return self._func(*args, **cleaned_kwargs)
+                    return self._call_task_func_with_hooks(args, cleaned_kwargs)
                 except Exception as e:
                     if not continue_on_fail_handler:
                         raise e
@@ -357,6 +362,8 @@ class TaskNode(Node):
                 id=guid,
                 name=sanitize_name(self._func.__name__),
                 func=self._func,
+                pre_func_hooks=self._pre_task_hook,
+                post_func_hooks=self._post_task_hook,
                 wait_for=self._get_wait(kwargs),
                 continue_on_fail=kwargs.get("continue_on_fail"),
                 exit=exit_handler,
@@ -371,6 +378,15 @@ class TaskNode(Node):
             return list(outputs.values())[0]
         else:
             return outputs
+
+    def _call_task_func_with_hooks(self, args, cleaned_kwargs):
+        if self._pre_task_hook is not None:
+            self._pre_task_hook()
+        try:
+            return self._func(*args, **cleaned_kwargs)
+        finally:
+            if self._post_task_hook is not None:
+                self._post_task_hook()
 
 
 class WorkflowTemplateNode(DAGNode):
@@ -462,6 +478,8 @@ class WorkflowTemplateNode(DAGNode):
                 id=guid,
                 name=sanitize_name(self._func.__name__),
                 func=self._func,
+                pre_func_hooks=None,
+                post_func_hooks=None,
                 wait_for=self._get_wait(kwargs),
                 arguments=self._arguments(arguments),
                 outputs=outputs,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "argo-workflow-tools"
-version = "0.9.34"
+version = "0.9.35"
 description = "A suite of tools to ease ML pipeline development with Argo Workflows"
 authors = ["Diagnostic Robotics"]
 license = "Apache 2.0"

--- a/tests/dsl/test_task_hooks.py
+++ b/tests/dsl/test_task_hooks.py
@@ -1,13 +1,15 @@
 from unittest.mock import Mock
 
+import pytest
+
 from argo_workflow_tools import dsl
 
 
-def test_export_to_yaml():
+def test_task_hooks_are_executed_properly():
     pre_hook_fuc = Mock()
     post_hook_fuc = Mock()
 
-    @dsl.Task(image="python:3.10", pre_task_hook=pre_hook_fuc, post_task_hook=post_hook_fuc)
+    @dsl.Task(image="python:3.10", pre_hook=pre_hook_fuc, post_hook=post_hook_fuc)
     def say_hello_with_hooks(name: str):
         message = f"hello {name}"
         return message
@@ -20,3 +22,42 @@ def test_export_to_yaml():
 
     pre_hook_fuc.assert_called_once()
     post_hook_fuc.assert_called_once()
+
+
+def test_failure_in_pre_hook_fails_the_task_and_the_post_hook_isnt_executed():
+    pre_hook_fuc = Mock()
+    pre_hook_fuc.side_effect = RuntimeError('something went wrong')
+    post_hook_fuc = Mock()
+
+    @dsl.Task(image="python:3.10", pre_hook=pre_hook_fuc, post_hook=post_hook_fuc)
+    def say_hello_with_hooks(name: str):
+        message = f"hello {name}"
+        return message
+
+    @dsl.WorkflowTemplate(name="test-workflow", arguments={"name": "name"})
+    def simple_workflow(name):
+        return say_hello_with_hooks(name)
+
+    with pytest.raises(RuntimeError, match='something went wrong'):
+        simple_workflow(name='Jessica')
+
+    pre_hook_fuc.assert_called_once()
+    assert not post_hook_fuc.called
+
+
+def test_failure_in_post_hook_fails_the_task():
+    pre_hook_fuc = Mock()
+    post_hook_fuc = Mock()
+    post_hook_fuc.side_effect = RuntimeError('something went wrong')
+
+    @dsl.Task(image="python:3.10", pre_hook=pre_hook_fuc, post_hook=post_hook_fuc)
+    def say_hello_with_hooks(name: str):
+        message = f"hello {name}"
+        return message
+
+    @dsl.WorkflowTemplate(name="test-workflow", arguments={"name": "name"})
+    def simple_workflow(name):
+        return say_hello_with_hooks(name)
+
+    with pytest.raises(RuntimeError, match='something went wrong'):
+        simple_workflow(name='Jessica')

--- a/tests/dsl/test_task_hooks.py
+++ b/tests/dsl/test_task_hooks.py
@@ -1,0 +1,22 @@
+from unittest.mock import Mock
+
+from argo_workflow_tools import dsl
+
+
+def test_export_to_yaml():
+    pre_hook_fuc = Mock()
+    post_hook_fuc = Mock()
+
+    @dsl.Task(image="python:3.10", pre_task_hook=pre_hook_fuc, post_task_hook=post_hook_fuc)
+    def say_hello_with_hooks(name: str):
+        message = f"hello {name}"
+        return message
+
+    @dsl.WorkflowTemplate(name="test-workflow", arguments={"name": "name"})
+    def simple_workflow(name):
+        return say_hello_with_hooks(name)
+
+    simple_workflow(name='Jessica')
+
+    pre_hook_fuc.assert_called_once()
+    post_hook_fuc.assert_called_once()

--- a/tests/dsl/test_workflow_compiler.py
+++ b/tests/dsl/test_workflow_compiler.py
@@ -6,8 +6,24 @@ from argo_workflow_tools.dsl import compile_workflow
 from argo_workflow_tools.models.io.argoproj.workflow.v1alpha1 import Artifact
 
 
+def pre_hook1():
+    from datetime import datetime
+    print(f'running from pre hook. datetime: {datetime.now()}')
+
+
+def post_hook1():
+    from datetime import datetime
+    print(f'running from post hook. datetime: {datetime.now()}')
+
+
 @dsl.Task(image="python:3.10")
 def say_hello(name: str):
+    message = f"hello {name}"
+    return message
+
+
+@dsl.Task(image="python:3.10", pre_task_hook=pre_hook1, post_task_hook=post_hook1)
+def say_hello_with_hooks(name: str):
     message = f"hello {name}"
     return message
 
@@ -17,6 +33,29 @@ def simple_workflow(name):
     return say_hello(name)
 
 
+@dsl.WorkflowTemplate(name="test-workflow", arguments={"name": "name"})
+def simple_workflow_with_task_hooks(name):
+    return say_hello_with_hooks(name)
+
+
 def test_export_to_yaml():
     workflow_yaml = compile_workflow(simple_workflow).to_yaml()
     print(workflow_yaml)
+
+
+def test_compiled_workflow_should_contain_the_code_of_its_dag_tasks():
+    workflow_model = compile_workflow(simple_workflow).to_model()
+    say_hello_task_template = next(filter(lambda template: template.name == 'say-hello',
+                                          workflow_model.spec.templates))
+
+    assert 'message = f"hello {name}"' in say_hello_task_template.script.source
+
+
+def test_compiled_workflow_should_contain_task_hooks():
+    workflow_model = compile_workflow(simple_workflow_with_task_hooks).to_model()
+    say_hello_task_template = next(filter(lambda template: template.name == 'say-hello-with-hooks',
+                                          workflow_model.spec.templates))
+
+    assert 'running from pre hook' in say_hello_task_template.script.source
+    assert 'message = f"hello {name}"' in say_hello_task_template.script.source
+    assert 'running from post hook' in say_hello_task_template.script.source

--- a/tests/dsl/test_workflow_compiler.py
+++ b/tests/dsl/test_workflow_compiler.py
@@ -22,7 +22,7 @@ def say_hello(name: str):
     return message
 
 
-@dsl.Task(image="python:3.10", pre_task_hook=pre_hook1, post_task_hook=post_hook1)
+@dsl.Task(image="python:3.10", pre_hook=pre_hook1, post_hook=post_hook1)
 def say_hello_with_hooks(name: str):
     message = f"hello {name}"
     return message


### PR DESCRIPTION
- added the optional arguments pre_func_hooks and post_func_hooks, and added them to the execution of the tasks both locally and from argo
- added the test case test_compiled_workflow_should_contain_the_code_of_its_dag_tasks, that covers the actual compiled code

When I ran the dsl tests of the current version of master (main) locally, without any local changes, these 3 tests failed:
* tests.dsl.test_loop_dag.test_loop_dag
* tests.dsl.test_loop_dag.test_loop_params_dag
* tests.dsl.test_workflow_reference.test_diammond_params_dag
After these changes, the same 3 tests are failing.