### PR TITLE
Use templateRefs compilation flag

### DIFF
--- a/argo_workflow_tools/dsl/dag_compiler.py
+++ b/argo_workflow_tools/dsl/dag_compiler.py
@@ -26,7 +26,7 @@ from argo_workflow_tools.dsl.utils.utils import (
     get_arguments,
     get_inputs,
     get_outputs,
-    sanitize_name,
+    sanitize_name, generate_template_name_from_func,
 )
 from argo_workflow_tools.models.io.argoproj.workflow import v1alpha1 as argo
 
@@ -172,8 +172,7 @@ def _fill_dag_metadata(task_template: argo.Template, properties: DAGNodeProperti
 
 def _generate_task_name_from_node_uid(nodes: List[NodeReference]) -> Dict[str, str]:
     node_names_by_id = {}
-    # groupby only groups consecutive elements therefore we need to sort them by name
-    # first
+    # groupby only groups consecutive elements therefore we need to sort them by name first
     sorted_nodes = sorted(nodes, key=lambda node_reference: node_reference.name)
     for name, group in groupby(
         sorted_nodes, key=lambda node_reference: node_reference.name
@@ -414,7 +413,7 @@ def _build_task_template(task_node: TaskReference) -> argo.Template:
     task_outputs = get_outputs(task_outputs)
 
     task_template = argo.Template(
-        name=sanitize_name(task_node.func.__name__),
+        name=generate_template_name_from_func(task_node.func),
         inputs=get_inputs(list(task_inputs.values())),
         script=argo.ScriptTemplate(
             image=task_node.properties.image, source=source, command=["python"]
@@ -471,7 +470,7 @@ def _build_dag_template(node: DAGNode, use_workflow_template_refs: bool) -> argo
 
     dag_template = argo.Template(
         dag=argo.DagTemplate(tasks=list(tasks)),
-        name=sanitize_name(node.func.__name__),
+        name=generate_template_name_from_func(node.func),
         outputs=get_outputs(dag_outputs),
         inputs=get_inputs(dag_inputs),
     )

--- a/argo_workflow_tools/dsl/dag_compiler.py
+++ b/argo_workflow_tools/dsl/dag_compiler.py
@@ -217,7 +217,7 @@ def build_condition(conditions: List[Union[BinaryOp, UnaryOp]]):
     return "&&".join(condition_expr)
 
 
-def _build_exit_hook(exit_hook: Callable) -> Dict[str, argo.LifecycleHook]:
+def _build_exit_hook(exit_hook: Callable, use_workflow_template_refs: bool) -> Dict[str, argo.LifecycleHook]:
     if exit_hook:
         ctx = copy_context()
         dag_output = ctx.run(exit_hook)
@@ -227,7 +227,7 @@ def _build_exit_hook(exit_hook: Callable) -> Dict[str, argo.LifecycleHook]:
             for input_name, input_type in dag_tasks[0].arguments.items()
         ]
         if isinstance(dag_tasks[0], DAGReference):
-            _build_dag_template(dag_tasks[0])
+            _build_dag_template(dag_tasks[0], use_workflow_template_refs)
         elif isinstance(dag_tasks[0], TaskReference):
             _build_task_template(dag_tasks[0])
         arguments = get_arguments(arguments)
@@ -240,7 +240,8 @@ def _build_exit_hook(exit_hook: Callable) -> Dict[str, argo.LifecycleHook]:
 
 
 def _build_dag_task(
-    dag_task: NodeReference, unique_node_names_map: Dict[str, str]
+    dag_task: NodeReference, unique_node_names_map: Dict[str, str],
+    use_workflow_template_refs: bool
 ) -> argo.DagTask:
     potential_deps = list(dag_task.arguments.values())
     potential_deps.extend(list() if dag_task.wait_for is None else dag_task.wait_for)
@@ -260,11 +261,12 @@ def _build_dag_task(
         for input_name, input_type in dag_task.arguments.items()
     ]
 
-    hook = _build_exit_hook(dag_task.exit)
+    hook = _build_exit_hook(dag_task.exit, use_workflow_template_refs)
     continue_on = argo.ContinueOn(failed=dag_task.continue_on_fail) if dag_task.continue_on_fail else None
 
-    if isinstance(dag_task, DAGReference):
-        dag = _build_dag_template(dag_task.node)
+    if isinstance(dag_task, DAGReference) or \
+            (isinstance(dag_task, WorkflowTemplateReference) and use_workflow_template_refs is False):
+        dag = _build_dag_template(dag_task.node, use_workflow_template_refs)
         task = argo.DagTask(
             name=dag_task.id,
             template=dag.name,
@@ -427,12 +429,13 @@ def _build_task_template(task_node: TaskReference) -> argo.Template:
     return task_template
 
 
-def _build_dag_template(node: DAGNode) -> argo.Template:
+def _build_dag_template(node: DAGNode, use_workflow_template_refs: bool) -> argo.Template:
     """
     Builds an Argo DAG Template out of a DAGNode
     Parameters
     ----------
     node : DAGNode to parse into a DAG Template
+    use_workflow_template_refs : boolean that determines whether to compile workflow template inline or use templateRefs
 
     Returns
     -------
@@ -464,7 +467,7 @@ def _build_dag_template(node: DAGNode) -> argo.Template:
     unique_node_names_map = _generate_task_name_from_node_uid(dag_tasks)
     dag_outputs = _build_dag_outputs(dag_output)
 
-    tasks = [_build_dag_task(dag_task, unique_node_names_map) for dag_task in dag_tasks]
+    tasks = [_build_dag_task(dag_task, unique_node_names_map, use_workflow_template_refs) for dag_task in dag_tasks]
 
     dag_template = argo.Template(
         dag=argo.DagTemplate(tasks=list(tasks)),
@@ -479,13 +482,14 @@ def _build_dag_template(node: DAGNode) -> argo.Template:
     return dag_template
 
 
-def compile_dag(entrypoint: DAGNode, on_exit: DAGNode = None) -> argo.WorkflowSpec:
+def compile_dag(entrypoint: DAGNode, on_exit: DAGNode = None, use_workflow_template_refs: bool = True) -> argo.WorkflowSpec:
     """
     compiles a DAG annotated function into a WorkflowSpec arg model
     Parameters
     ----------
     entrypoint : DAG entrypoint
     on_exit : on_exit DAG entrypoint
+    use_workflow_template_refs : boolean that determines whether to compile workflow template inline or use templateRefs
 
     Returns
     -------
@@ -498,10 +502,10 @@ def compile_dag(entrypoint: DAGNode, on_exit: DAGNode = None) -> argo.WorkflowSp
             raise ValueError(
                 f"{entrypoint.__name__} is not decorated with DAG or Task decorator"
             )
-        result = _build_dag_template(entrypoint)
+        result = _build_dag_template(entrypoint, use_workflow_template_refs)
 
         if on_exit:
-            on_exit_result = _build_dag_template(on_exit).name
+            on_exit_result = _build_dag_template(on_exit, use_workflow_template_refs).name
         else:
             on_exit_result = None
 

--- a/argo_workflow_tools/dsl/dag_task.py
+++ b/argo_workflow_tools/dsl/dag_task.py
@@ -11,7 +11,7 @@ from argo_workflow_tools.dsl.node_properties import (
 @dataclass
 class NodeReference(object):
     """
-    Represents a result referece from a called node
+    Represents a result reference from a called node
     """
 
     id: str
@@ -31,7 +31,7 @@ class NodeReference(object):
 @dataclass
 class DAGReference(NodeReference):
     """
-    Represents a result referece from a called DAG
+    Represents a result reference from a called DAG
     """
 
     properties: DAGNodeProperties
@@ -40,7 +40,7 @@ class DAGReference(NodeReference):
 @dataclass
 class TaskReference(NodeReference):
     """
-    Represents a result referece from a called task
+    Represents a result reference from a called task
     """
 
     properties: TaskNodeProperties
@@ -52,7 +52,7 @@ class TaskReference(NodeReference):
 @dataclass
 class WorkflowTemplateReference(NodeReference):
     """
-    Represents a result referece from a called task
+    Represents a result reference from a called task
     """
 
     workflow_template_name: str

--- a/argo_workflow_tools/dsl/utils/utils.py
+++ b/argo_workflow_tools/dsl/utils/utils.py
@@ -1,4 +1,4 @@
-from typing import Union, List, Dict, Tuple
+from typing import Union, List, Dict, Tuple, Callable
 import json
 
 import shortuuid
@@ -81,6 +81,11 @@ def sanitize_name(name: str, snake_case=False) -> str:
     if snake_case:
         return name
     return name.replace("_", "-")
+
+
+def generate_template_name_from_func(func: Callable, snake_case=False) -> str:
+    sanitized = sanitize_name(func.__name__, snake_case)
+    return f'{sanitized}-{func.__hash__()}'
 
 
 def convert_str(value: any) -> str:

--- a/argo_workflow_tools/dsl/utils/utils.py
+++ b/argo_workflow_tools/dsl/utils/utils.py
@@ -85,7 +85,8 @@ def sanitize_name(name: str, snake_case=False) -> str:
 
 def generate_template_name_from_func(func: Callable, snake_case=False) -> str:
     sanitized = sanitize_name(func.__name__, snake_case)
-    return f'{sanitized}-{func.__hash__()}'
+    hash_value = func.__hash__() % 1_000_000  # Limit to 6 digits
+    return f'{sanitized}-{hash_value}'
 
 
 def convert_str(value: any) -> str:

--- a/argo_workflow_tools/dsl/workflow.py
+++ b/argo_workflow_tools/dsl/workflow.py
@@ -46,11 +46,11 @@ class WorkflowTemplate:
         self.workflow_labels: Dict[str, str] = workflow_labels
         self.workflow_annotations: Dict[str, str] = workflow_annotations
 
-    def to_model(self, use_workflow_template_refs: bool = True) -> argo.WorkflowTemplate:
+    def to_model(self, embed_workflow_templates: bool = False) -> argo.WorkflowTemplate:
         """
         convert workflow to pydantic model
         """
-        spec = compile_dag(self.entrypoint, self.on_exit, use_workflow_template_refs)
+        spec = compile_dag(self.entrypoint, self.on_exit, embed_workflow_templates)
         spec.arguments = get_arguments(self.arguments)
 
         return argo.WorkflowTemplate(
@@ -71,17 +71,17 @@ class WorkflowTemplate:
             )
         )
 
-    def to_dict(self, use_workflow_template_refs: bool = True) -> dict:
+    def to_dict(self, embed_workflow_templates: bool = False) -> dict:
         """
         convert workflow to dictionary
         """
-        return delete_none(self.to_model(use_workflow_template_refs).dict(by_alias=True))
+        return delete_none(self.to_model(embed_workflow_templates).dict(by_alias=True))
 
-    def to_yaml(self, use_workflow_template_refs: bool = True) -> str:
+    def to_yaml(self, embed_workflow_templates: bool = False) -> str:
         """
         convert workflow to yaml
         """
-        return yaml.dump(self.to_dict(use_workflow_template_refs))
+        return yaml.dump(self.to_dict(embed_workflow_templates))
 
 
 class CronWorkflow:
@@ -126,11 +126,11 @@ class CronWorkflow:
         self.on_exit: Callable = on_exit
         self.suspend: bool = suspend
 
-    def to_model(self, use_workflow_template_refs: bool = True) -> argo.CronWorkflow:
+    def to_model(self, embed_workflow_templates: bool = False) -> argo.CronWorkflow:
         """
         convert workflow to pydantic model
         """
-        wf_spec = compile_dag(self.entrypoint, self.on_exit, use_workflow_template_refs)
+        wf_spec = compile_dag(self.entrypoint, self.on_exit, embed_workflow_templates)
         wf_spec.arguments = get_arguments(self.arguments)
         spec = argo.CronWorkflowSpec(
             workflowSpec=wf_spec,
@@ -152,17 +152,17 @@ class CronWorkflow:
             spec=spec,
         )
 
-    def to_dict(self, use_workflow_template_refs: bool = True) -> dict:
+    def to_dict(self, embed_workflow_templates: bool = False) -> dict:
         """
         convert workflow to dictionary
         """
-        return delete_none(self.to_model(use_workflow_template_refs).dict(by_alias=True))
+        return delete_none(self.to_model(embed_workflow_templates).dict(by_alias=True))
 
-    def to_yaml(self, use_workflow_template_refs: bool = True) -> str:
+    def to_yaml(self, embed_workflow_templates: bool = False) -> str:
         """
         convert workflow to dictionary
         """
-        return yaml.dump(self.to_dict(use_workflow_template_refs))
+        return yaml.dump(self.to_dict(embed_workflow_templates))
 
 
 class Workflow:
@@ -186,7 +186,7 @@ class Workflow:
         self.generated_name = generated_name
         self.on_exit: Callable = on_exit
 
-    def to_model(self, use_workflow_template_refs: bool = True) -> argo.Workflow:
+    def to_model(self, embed_workflow_templates: bool = False) -> argo.Workflow:
         """
         convert workflow to pydantic model
         """
@@ -194,7 +194,7 @@ class Workflow:
             raise ValueError(
                 "you must specify at least name or generated name arguments for a workflow"
             )
-        spec = compile_dag(self.entrypoint, self.on_exit, use_workflow_template_refs)
+        spec = compile_dag(self.entrypoint, self.on_exit, embed_workflow_templates)
         spec.arguments = get_arguments(self.arguments)
         workflow = argo.Workflow(
             apiVersion="argoproj.io/v1alpha1",
@@ -210,14 +210,14 @@ class Workflow:
         )
         return workflow
 
-    def to_dict(self, use_workflow_template_refs: bool = True) -> dict:
+    def to_dict(self, embed_workflow_templates: bool = False) -> dict:
         """
         convert workflow to dictionary
         """
-        return delete_none(self.to_model(use_workflow_template_refs).dict(by_alias=True))
+        return delete_none(self.to_model(embed_workflow_templates).dict(by_alias=True))
 
-    def to_yaml(self, use_workflow_template_refs: bool = True) -> str:
+    def to_yaml(self, embed_workflow_templates: bool = False) -> str:
         """
         convert workflow to dictionary
         """
-        return yaml.dump(self.to_dict(use_workflow_template_refs))
+        return yaml.dump(self.to_dict(embed_workflow_templates))

--- a/argo_workflow_tools/dsl/workflow.py
+++ b/argo_workflow_tools/dsl/workflow.py
@@ -46,11 +46,11 @@ class WorkflowTemplate:
         self.workflow_labels: Dict[str, str] = workflow_labels
         self.workflow_annotations: Dict[str, str] = workflow_annotations
 
-    def to_model(self) -> argo.WorkflowTemplate:
+    def to_model(self, use_workflow_template_refs: bool = True) -> argo.WorkflowTemplate:
         """
         convert workflow to pydantic model
         """
-        spec = compile_dag(self.entrypoint, self.on_exit)
+        spec = compile_dag(self.entrypoint, self.on_exit, use_workflow_template_refs)
         spec.arguments = get_arguments(self.arguments)
 
         return argo.WorkflowTemplate(
@@ -71,17 +71,17 @@ class WorkflowTemplate:
             )
         )
 
-    def to_dict(self) -> dict:
+    def to_dict(self, use_workflow_template_refs: bool = True) -> dict:
         """
         convert workflow to dictionary
         """
-        return delete_none(self.to_model().dict(by_alias=True))
+        return delete_none(self.to_model(use_workflow_template_refs).dict(by_alias=True))
 
-    def to_yaml(self) -> str:
+    def to_yaml(self, use_workflow_template_refs: bool = True) -> str:
         """
         convert workflow to yaml
         """
-        return yaml.dump(self.to_dict())
+        return yaml.dump(self.to_dict(use_workflow_template_refs))
 
 
 class CronWorkflow:
@@ -126,11 +126,11 @@ class CronWorkflow:
         self.on_exit: Callable = on_exit
         self.suspend: bool = suspend
 
-    def to_model(self) -> argo.CronWorkflow:
+    def to_model(self, use_workflow_template_refs: bool = True) -> argo.CronWorkflow:
         """
         convert workflow to pydantic model
         """
-        wf_spec = compile_dag(self.entrypoint, self.on_exit)
+        wf_spec = compile_dag(self.entrypoint, self.on_exit, use_workflow_template_refs)
         wf_spec.arguments = get_arguments(self.arguments)
         spec = argo.CronWorkflowSpec(
             workflowSpec=wf_spec,
@@ -152,17 +152,17 @@ class CronWorkflow:
             spec=spec,
         )
 
-    def to_dict(self) -> dict:
+    def to_dict(self, use_workflow_template_refs: bool = True) -> dict:
         """
         convert workflow to dictionary
         """
-        return delete_none(self.to_model().dict(by_alias=True))
+        return delete_none(self.to_model(use_workflow_template_refs).dict(by_alias=True))
 
-    def to_yaml(self) -> str:
+    def to_yaml(self, use_workflow_template_refs: bool = True) -> str:
         """
         convert workflow to dictionary
         """
-        return yaml.dump(self.to_dict())
+        return yaml.dump(self.to_dict(use_workflow_template_refs))
 
 
 class Workflow:
@@ -186,7 +186,7 @@ class Workflow:
         self.generated_name = generated_name
         self.on_exit: Callable = on_exit
 
-    def to_model(self) -> argo.Workflow:
+    def to_model(self, use_workflow_template_refs: bool = True) -> argo.Workflow:
         """
         convert workflow to pydantic model
         """
@@ -194,7 +194,7 @@ class Workflow:
             raise ValueError(
                 "you must specify at least name or generated name arguments for a workflow"
             )
-        spec = compile_dag(self.entrypoint, self.on_exit)
+        spec = compile_dag(self.entrypoint, self.on_exit, use_workflow_template_refs)
         spec.arguments = get_arguments(self.arguments)
         workflow = argo.Workflow(
             apiVersion="argoproj.io/v1alpha1",
@@ -210,14 +210,14 @@ class Workflow:
         )
         return workflow
 
-    def to_dict(self) -> dict:
+    def to_dict(self, use_workflow_template_refs: bool = True) -> dict:
         """
         convert workflow to dictionary
         """
-        return delete_none(self.to_model().dict(by_alias=True))
+        return delete_none(self.to_model(use_workflow_template_refs).dict(by_alias=True))
 
-    def to_yaml(self) -> str:
+    def to_yaml(self, use_workflow_template_refs: bool = True) -> str:
         """
         convert workflow to dictionary
         """
-        return yaml.dump(self.to_dict())
+        return yaml.dump(self.to_dict(use_workflow_template_refs))

--- a/argo_workflow_tools/dsl/workflow_template_collector.py
+++ b/argo_workflow_tools/dsl/workflow_template_collector.py
@@ -50,7 +50,7 @@ _workflow_templates: ContextVar[List[Template]] = ContextVar("workflow_templates
 
 def add_template(template: Template) -> None:
     """
-    add tempalte to the current workflow compilation flow
+    add template to the current workflow compilation flow
     Parameters
     ----------
     template : called template reference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "argo-workflow-tools"
-version = "0.9.44"
+version = "0.9.45"
 description = "A suite of tools to ease ML pipeline development with Argo Workflows"
 authors = ["Diagnostic Robotics"]
 license = "Apache 2.0"

--- a/tests/dsl/test_duplicated_task_names.py
+++ b/tests/dsl/test_duplicated_task_names.py
@@ -47,7 +47,7 @@ def test_dag_compilation_generates_one_template_per_method_with_unique_name():
     workflow = Workflow(
         name="hello-world", entrypoint=dag, arguments={"name": "Brian"}
     )
-    compiled = workflow.to_model(use_workflow_template_refs=False)
+    compiled = workflow.to_model(embed_workflow_templates=True)
     templates = compiled.spec.templates
     assert len(templates) == 5
 

--- a/tests/dsl/test_duplicated_task_names.py
+++ b/tests/dsl/test_duplicated_task_names.py
@@ -1,0 +1,66 @@
+from argo_workflow_tools import dsl, Workflow
+from argo_workflow_tools.dsl.parameter_builders import DefaultParameterBuilder
+
+
+class ModuleWithFunction1:
+    @staticmethod
+    @dsl.Task(image="python:3.10")
+    def say_hello(name: str):
+        message = f"hello {name}"
+        return message
+
+
+class ModuleWithFunction2:
+    @staticmethod
+    @dsl.Task(image="python:3.10")
+    # Different method than the one above but with the same name, compilation should create a different template
+    def say_hello(name: str):
+        message = f"hello {name} 2"
+        return message
+
+
+@dsl.WorkflowTemplate(
+    name="wf-template1",
+    outputs={"result": DefaultParameterBuilder(any)},
+)
+def workflow_template1(name):
+    return ModuleWithFunction1.say_hello(name)
+
+
+@dsl.WorkflowTemplate(
+    name="wf-template2",
+    outputs={"result": DefaultParameterBuilder(any)},
+)
+def workflow_template2(name):
+    return ModuleWithFunction2.say_hello(name)
+
+
+@dsl.DAG()
+def dag():
+    message = workflow_template1("Eden")
+    message = workflow_template1("Ben")  # We invoke template1 twice, and expect only 1 template
+    message = workflow_template2("Zaken")
+    return message
+
+
+def test_dag_compilation_generates_one_template_per_method_with_unique_name():
+    workflow = Workflow(
+        name="hello-world", entrypoint=dag, arguments={"name": "Brian"}
+    )
+    compiled = workflow.to_model(use_workflow_template_refs=False)
+    templates = compiled.spec.templates
+    assert len(templates) == 5
+
+    say_hellos = _filter_templates_by_prefix(templates, 'say-hello-')
+    assert len(say_hellos) == 2
+    assert say_hellos[0].name != say_hellos[1].name
+    assert say_hellos[0].script.source != say_hellos[1].script.source
+
+    assert len(_filter_templates_by_prefix(templates, 'workflow-template1-')) == 1
+    assert len(_filter_templates_by_prefix(templates, 'workflow-template2-')) == 1
+    assert len(_filter_templates_by_prefix(templates, 'dag-')) == 1
+    print(compiled)
+
+
+def _filter_templates_by_prefix(templates, prefix: str):
+    return [t for t in templates if t.name.startswith(prefix)]

--- a/tests/dsl/test_on_dag_exit_dag.py
+++ b/tests/dsl/test_on_dag_exit_dag.py
@@ -54,7 +54,7 @@ def test_on_exit_on_task_compile():
     hooks = model.spec.templates[2].dag.tasks[0].hooks
     assert hooks is not None
     assert hooks["exit"] is not None
-    assert hooks["exit"].template == "say-goodbye"
+    assert hooks["exit"].template.startswith("say-goodbye-")
     assert hooks["exit"].arguments.parameters[0].name == "name"
     assert hooks["exit"].arguments.parameters[0].value == "{{inputs.parameters.name}}"
 
@@ -71,6 +71,6 @@ def test_on_exit_on_dag_compile():
     hooks = model.spec.templates[3].dag.tasks[0].hooks
     assert hooks is not None
     assert hooks["exit"] is not None
-    assert hooks["exit"].template == "dag-goodbye"
+    assert hooks["exit"].template.startswith("dag-goodbye-")
     assert hooks["exit"].arguments.parameters[0].name == "name"
     assert hooks["exit"].arguments.parameters[0].value == "{{inputs.parameters.name}}"

--- a/tests/dsl/test_on_exit_dag.py
+++ b/tests/dsl/test_on_exit_dag.py
@@ -28,10 +28,10 @@ def test_on_exit_dag():
         arguments={"name": "james"},
     )
     model = workflow.to_model()
-    assert model.spec.on_exit == "on-exit"
+    assert model.spec.on_exit.startswith("on-exit-")
     on_exit_template = model.spec.templates[3]
 
     assert on_exit_template.dag is not None, "on-exit dag does not exist"
     assert (
-        on_exit_template.dag.tasks[0].template == "say-goodbye"
+        on_exit_template.dag.tasks[0].template.startswith("say-goodbye-")
     ), "dag does not reference goodbye task"

--- a/tests/dsl/test_task_with_pydantic_parameters.py
+++ b/tests/dsl/test_task_with_pydantic_parameters.py
@@ -28,7 +28,7 @@ def test_pydantic_input_parameter_compilation():
     model = compiled_template.to_model()
 
     # Assert
-    say_hello_task_template = next(filter(lambda t: t.name == 'say-hello', model.spec.templates))
+    say_hello_task_template = next(filter(lambda t: t.name.startswith('say-hello-'), model.spec.templates))
     pydantic_input_parsing_script_lines = re.findall(
         rf'.*=.*{PydanticObj.__name__}.parse_raw\(.*\).*', say_hello_task_template.script.source)
     assert len(pydantic_input_parsing_script_lines) == 1, \
@@ -51,7 +51,7 @@ def test_pydantic_output_parameter_compilation():
     model = compiled_template.to_model()
 
     # Assert
-    say_hello_task_template = next(filter(lambda t: t.name == 'say-hello', model.spec.templates))
+    say_hello_task_template = next(filter(lambda t: t.name.startswith('say-hello-'), model.spec.templates))
     pydantic_output_formatting_script_lines = re.findall(
         r'file\.write(.*\.json\(\))', say_hello_task_template.script.source)
     assert len(pydantic_output_formatting_script_lines) == 1, \

--- a/tests/dsl/test_workflow_compiler.py
+++ b/tests/dsl/test_workflow_compiler.py
@@ -45,7 +45,7 @@ def test_export_to_yaml():
 
 def test_compiled_workflow_should_contain_the_code_of_its_dag_tasks():
     workflow_model = compile_workflow(simple_workflow).to_model()
-    say_hello_task_template = next(filter(lambda template: template.name == 'say-hello',
+    say_hello_task_template = next(filter(lambda template: template.name.startswith('say-hello-'),
                                           workflow_model.spec.templates))
 
     assert 'message = f"hello {name}"' in say_hello_task_template.script.source
@@ -53,7 +53,7 @@ def test_compiled_workflow_should_contain_the_code_of_its_dag_tasks():
 
 def test_compiled_workflow_should_contain_task_hooks():
     workflow_model = compile_workflow(simple_workflow_with_task_hooks).to_model()
-    say_hello_task_template = next(filter(lambda template: template.name == 'say-hello-with-hooks',
+    say_hello_task_template = next(filter(lambda template: template.name.startswith('say-hello-with-hooks-'),
                                           workflow_model.spec.templates))
 
     assert 'running from pre hook' in say_hello_task_template.script.source

--- a/tests/dsl/test_workflow_reference.py
+++ b/tests/dsl/test_workflow_reference.py
@@ -13,10 +13,10 @@ def say_hello(name: str):
 
 @dsl.WorkflowTemplate(
     name="model-train-cookbook",
-    outputs={"selected-model": DefaultParameterBuilder(any)},
+    outputs={"result": DefaultParameterBuilder(any)},
 )
 def model_train_template(name):
-    pass
+    return say_hello(name)
 
 
 @dsl.DAG()
@@ -25,13 +25,24 @@ def wf_hello():
     return message
 
 
-def test_diamond_params_run_independently():
+def test_dag_runs_independently():
     result = wf_hello()
-    assert result == None
+    assert result == "hello jose"
 
 
-def test_diammond_params_dag():
+def test_wf_params_compilation():
     workflow = Workflow(
         name="hello-world", entrypoint=wf_hello, arguments={"name": "Brian"}
     )
-    print(workflow.to_yaml())
+    compiled = workflow.to_yaml(use_workflow_template_refs=True)
+    assert "templateRef" in compiled
+    print(compiled)
+
+
+def test_wf_params_compilation_without_refs():
+    workflow = Workflow(
+        name="hello-world", entrypoint=wf_hello, arguments={"name": "Brian"}
+    )
+    compiled = workflow.to_yaml(use_workflow_template_refs=False)
+    assert "templateRef" not in compiled
+    print(compiled)

--- a/tests/dsl/test_workflow_reference.py
+++ b/tests/dsl/test_workflow_reference.py
@@ -34,7 +34,7 @@ def test_wf_params_compilation():
     workflow = Workflow(
         name="hello-world", entrypoint=wf_hello, arguments={"name": "Brian"}
     )
-    compiled = workflow.to_yaml(use_workflow_template_refs=True)
+    compiled = workflow.to_yaml(embed_workflow_templates=False)
     assert "templateRef" in compiled
     print(compiled)
 
@@ -43,6 +43,6 @@ def test_wf_params_compilation_without_refs():
     workflow = Workflow(
         name="hello-world", entrypoint=wf_hello, arguments={"name": "Brian"}
     )
-    compiled = workflow.to_yaml(use_workflow_template_refs=False)
+    compiled = workflow.to_yaml(embed_workflow_templates=True)
     assert "templateRef" not in compiled
     print(compiled)


### PR DESCRIPTION
Add a flag to the compilation methods to control whether to use templateRefs or not

This will enable us to move out from using workflow templates in argo.

Additionally this PR modifies the template name generation for tasks and dags, we now add the decorated method's hash value to its template name so we can use multiple methods with same names in a single workflow.