### PR TITLE
Convert to sha1 hashing which is consistent

### DIFF
--- a/argo_workflow_tools/dsl/dag_compiler.py
+++ b/argo_workflow_tools/dsl/dag_compiler.py
@@ -294,10 +294,11 @@ def _build_dag_task(
         )
         return task
     elif isinstance(dag_task, WorkflowTemplateReference):
+        template_name = generate_template_name_from_func(dag_task.func)
         task = argo.DagTask(
             name=dag_task.id,
             templateRef=argo.TemplateRef(
-                name=dag_task.workflow_template_name, template=dag_task.name
+                name=dag_task.workflow_template_name, template=template_name
             ),
             dependencies=list(dependencies),
             hooks=hook,

--- a/argo_workflow_tools/dsl/utils/utils.py
+++ b/argo_workflow_tools/dsl/utils/utils.py
@@ -1,6 +1,6 @@
 from typing import Union, List, Dict, Tuple, Callable
 import json
-
+import hashlib
 import shortuuid
 from pydantic import BaseModel
 
@@ -85,7 +85,9 @@ def sanitize_name(name: str, snake_case=False) -> str:
 
 def generate_template_name_from_func(func: Callable, snake_case=False) -> str:
     sanitized = sanitize_name(func.__name__, snake_case)
-    hash_value = func.__hash__() % 1_000_000  # Limit to 6 digits
+    module = func.__module__
+    name = func.__qualname__
+    hash_value = hashlib.sha1(str((module, name)).encode()).hexdigest()[:6]
     return f'{sanitized}-{hash_value}'
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "argo-workflow-tools"
-version = "0.9.45"
+version = "0.9.46"
 description = "A suite of tools to ease ML pipeline development with Argo Workflows"
 authors = ["Diagnostic Robotics"]
 license = "Apache 2.0"


### PR DESCRIPTION
…throughout different invocations and fix template names for template refs.

Python's builtin hash methods is not consistent through different invocations, this leads to different template names for the same method in every compilation.

This has no harm if we're embedding all templates in a single yaml, but in the case we use workflow template refs and the refs and the workflow invoking them were not compiled in the same process, we'll get an error.

This PR uses SHA1 hashing on method's module + qualified name instead of python's built in hashing.